### PR TITLE
There is only 1 Volatile Bomb in JotL

### DIFF
--- a/src/games/jotl/items.json
+++ b/src/games/jotl/items.json
@@ -254,7 +254,7 @@
       {
         "id": 24,
         "name": "Volatile Bomb",
-        "count": 2,
+        "count": 1,
         "cost": 40,
         "slot": "One Hand",
         "source": "Reward from Scenario #15",


### PR DESCRIPTION
Just that.  A friend and I counted today to verify this, there are only 52 JotL item cards.