### PR TITLE
Alter itemIsShown logic for imported items

### DIFF
--- a/src/hooks/useIsItemShown.tsx
+++ b/src/hooks/useIsItemShown.tsx
@@ -88,7 +88,9 @@ export const useIsItemShown = (): ((item: GloomhavenItem) => boolean) => {
 				) {
 					return false;
 				}
-				return item.includes(id);
+				if(!item.includes(id)){
+					return false
+				}
 			}
 			let show =
 				all ||


### PR DESCRIPTION
Allow filtering of imported items by falling through to the remaining filter logic. This should resolve a bug where imported GH items in FH don't filter by item slot or party member.

I was unable to test this locally, but messing around in the debugger I think this should work. Please consider merging this if it doesn't break other use cases.  